### PR TITLE
Update 2019-09-14-diy-vanilla-jquery-alternative.md

### DIFF
--- a/_posts/2019-09-14-diy-vanilla-jquery-alternative.md
+++ b/_posts/2019-09-14-diy-vanilla-jquery-alternative.md
@@ -85,7 +85,7 @@ lemonReady( function() {
 
 	// Loop items.
 	for ( var i = 0; i < items.length; i++ ) {
-		let item = items.length[ i ];
+		let item = items[ i ];
 
 		// Add a class.
 		item.classList.add( 'foo' );


### PR DESCRIPTION
As the `querySelectorAll` returns an array 'items' so there can't an index of `items.length` which returns only a single value.

I intended just to change line 88. Not sure why it's showing line 584 also which is unchanged.
